### PR TITLE
switching from pivot_table to pivot 

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -502,7 +502,7 @@ def create_fib_df(nwb_filename, tidy=False):
 
     # pivot table based on timestamps
     if not tidy:
-        df_pivoted = pd.pivot(fib_df_tidy, index='timestamps',columns=['event'], values='data')
+        df_pivoted = pd.pivot(df, index="timestamps", columns=["event"], values="data")
         return df_pivoted
     else:
         return df


### PR DESCRIPTION
`pivot_table` aggregates duplicate entries, but `pivot` throws an error. We should expect to never have duplicate entries. 

This would have caught this error: https://github.com/AllenNeuralDynamics/aind-fip-dff/issues/10