### PR TITLE
Change absolute time reference to first go cue

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -329,7 +329,7 @@ def create_df_trials(nwb_filename):
     df_ses_trials["ses_idx"] = ses_idx
 
     # Adjust all times relative to start of the first trial
-    t0 = df_ses_trials.start_time[0]
+    t0 = df_ses_trials.goCue_start_time[0]
     skip_cols = ["right_valve_open_time", "left_valve_open_time"]
     for col in df_ses_trials.columns:
         if ("time" in col) and (col not in skip_cols):

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -303,7 +303,17 @@ def create_df_trials(nwb_filename, adjust_time=True):
     """
     Process nwb and create df_trials for every single session
 
+    ARGS:
+    nwb_filename (str or NWB object), the session to extract the trials from
     adjust_time (bool) if true, adjust t0 to be the first gocue
+
+    RETURNS:
+    A pandas dataframe containing the columns of nwb.trials plus:
+    "_in_trial" time alignments where time is relative to the go cue on that trial
+    "_in_session" time alignments where time is relative to the first go cue
+        of the session.
+    earned_reward, (0 or 1) whether a reward was earned in that trial
+    extra_reward (bool) whether a manual reward was given in that trial
     """
 
     # If we are given a filename, load the NWB object itself
@@ -435,7 +445,6 @@ def create_df_trials(nwb_filename, adjust_time=True):
             df.query("earned_reward == 0").query("extra_reward == 0")["reward_time_in_session"]
         )
     ), "Unrewarded trials with reward time"
-    # TODO, documentation of added columns
 
     # Drop columns
     drop_cols += key_from_acq

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -426,6 +426,7 @@ def create_df_trials(nwb_filename, adjust_time=True):
     df.loc[slow_choice, "choice_time_in_trial"] = np.nan
 
     # Compute boolean of whether animal was rewarded
+    # AutoWater and manual water is not included in earned_reward
     df["earned_reward"] = df.rewarded_historyR.astype(int) | df.rewarded_historyL.astype(int)
     df["extra_reward"] = (df["earned_reward"] == 0) & df["reward_time_in_session"].notnull()
 
@@ -449,6 +450,8 @@ def create_df_trials(nwb_filename, adjust_time=True):
         )
     ), "Unrewarded trials with reward time"
     # TODO, auto water can be delievered before choice time
+    # TODO, assigning choice/reward should check for left/right
+
 
     # Drop columns
     drop_cols += key_from_acq

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -490,7 +490,10 @@ def create_events_df(nwb_filename, adjust_time=True):
     event_types -= ignore_types
 
     # Determine time 0 as first go Cue
-    t0 = nwb.trials.goCue_start_time[0]
+    if adjust_time:
+        t0 = nwb.trials.goCue_start_time[0]
+    else:
+        t0 = 0
 
     # Iterate over event types and build a dataframe of each
     events = []
@@ -499,8 +502,7 @@ def create_events_df(nwb_filename, adjust_time=True):
         stamps = nwb.acquisition[e].timestamps[:]
         data = nwb.acquisition[e].data[:]
         labels = [e] * len(data)
-        if adjust_time:
-            stamps = stamps - t0
+        stamps = stamps - t0
         df = pd.DataFrame({"timestamps": stamps, "data": data, "event": labels})
         events.append(df)
 
@@ -509,8 +511,7 @@ def create_events_df(nwb_filename, adjust_time=True):
     for e in trial_events:
         stamps = nwb.trials[:][e].values
         labels = [e] * len(stamps)
-        if adjust_time:
-            stamps = stamps - t0
+        stamps = stamps - t0
         df = pd.DataFrame({"timestamps": stamps, "event": labels})
         events.append(df)
 
@@ -520,12 +521,8 @@ def create_events_df(nwb_filename, adjust_time=True):
     df = df.dropna(subset="timestamps").reset_index(drop=True)
 
     # Add trial index for each event
-    if adjust_time:
-        trial_starts = nwb.trials.start_time[:] - t0
-        last_stop = nwb.trials.stop_time[-1] - t0
-    else:
-        trial_starts = nwb.trials.start_time[:]
-        last_stop = nwb.trials.stop_time[-1]
+    trial_starts = nwb.trials.start_time[:] - t0
+    last_stop = nwb.trials.stop_time[-1] - t0
     trial_index = []
     for index, e in df.iterrows():
         starts = np.where(e.timestamps > trial_starts)[0]

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -328,7 +328,7 @@ def create_df_trials(nwb_filename):
     df_ses_trials = df_ses_trials.rename(columns={"id": "trial"})
     df_ses_trials["ses_idx"] = ses_idx
 
-    # Adjust all times relative to start of the first trial
+    # Adjust all times relative to start of the first go cue
     t0 = df_ses_trials.goCue_start_time[0]
     skip_cols = ["right_valve_open_time", "left_valve_open_time"]
     for col in df_ses_trials.columns:
@@ -461,8 +461,8 @@ def create_events_df(nwb_filename, adjust_time=True):
     )
     event_types -= ignore_types
 
-    # Determine time 0
-    t0 = nwb.trials.start_time[0]
+    # Determine time 0 as first go Cue
+    t0 = nwb.trials.goCue_start_time[0]
 
     # Iterate over event types and build a dataframe of each
     events = []
@@ -560,7 +560,7 @@ def create_fib_df(nwb_filename, tidy=True, adjust_time=True):
         return None
 
     # Determine time 0
-    t0 = nwb.trials.start_time[0]
+    t0 = nwb.trials.goCue_start_time[0]
 
     # Iterate over event types and build a dataframe of each
     events = []

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -341,7 +341,7 @@ def create_df_trials(nwb_filename):
         -1, fill_value=last_stop
     )
 
-    # Adjust times relative to go cue
+    # Adjust times relative to go cue on each trial
     for col in df_ses_trials.columns:
         if (
             ("time" in col)
@@ -354,6 +354,12 @@ def create_df_trials(nwb_filename):
             )
     df_ses_trials["goCue_start_time"] = 0.0
 
+    # TODO, CHECK FROM HERE
+    # TODO, a unit test that checks that the goCue_start_time in df_events matches goCue_start_time absolute in df_trials
+    # TODO, a unit test that matches that right/left licks in df_events.trial==i matches df_trials.loc[i]
+    # TODO, same with reward times
+    # TODO Trial 11, we seem to have a mismatch in reward_time
+    # TODO Trial 15, choice time mismatch
     # Adjust event times relative to trial
     events_ses = {key: nwb.acquisition[key].timestamps[:] - t0 for key in key_from_acq}
     for event in [
@@ -373,7 +379,7 @@ def create_df_trials(nwb_filename):
                 4,
             ),
             axis=1,
-        )
+        ) #TODO, something feels wrong here. event_times should be relative to t0
 
     # Compute time of reward for each trial
     df_ses_trials["reward_time"] = df_ses_trials.apply(
@@ -415,6 +421,7 @@ def create_df_trials(nwb_filename):
             "right_reward_delivery_time",
         ]
     )
+    # TODO CHECK TO HERE
     return df_ses_trials
 
 
@@ -493,9 +500,9 @@ def create_events_df(nwb_filename, adjust_time=True):
     df = df.sort_values(by="timestamps")
     df = df.dropna(subset="timestamps").reset_index(drop=True)
 
-    # Add trial index for each event
-    trial_starts = nwb.trials.start_time[:] - nwb.trials.start_time[0]
-    last_stop = nwb.trials.stop_time[-1] - nwb.trials.start_time[0]
+    # Add trial index for each event 
+    trial_starts = nwb.trials.start_time[:] - nwb.trials.goCue_start_time[0]
+    last_stop = nwb.trials.stop_time[-1] - nwb.trials.goCue_start_time[0]
     trial_index = []
     for index, e in df.iterrows():
         starts = np.where(e.timestamps > trial_starts)[0]
@@ -597,3 +604,6 @@ def create_fib_df(nwb_filename, tidy=True, adjust_time=True):
         return df_pivoted
     else:
         return df
+
+
+

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -379,7 +379,7 @@ def create_df_trials(nwb_filename):
                 4,
             ),
             axis=1,
-        ) #TODO, something feels wrong here. event_times should be relative to t0
+        )  # TODO, something feels wrong here. event_times should be relative to t0
 
     # Compute time of reward for each trial
     df_ses_trials["reward_time"] = df_ses_trials.apply(
@@ -500,7 +500,7 @@ def create_events_df(nwb_filename, adjust_time=True):
     df = df.sort_values(by="timestamps")
     df = df.dropna(subset="timestamps").reset_index(drop=True)
 
-    # Add trial index for each event 
+    # Add trial index for each event
     trial_starts = nwb.trials.start_time[:] - nwb.trials.goCue_start_time[0]
     last_stop = nwb.trials.stop_time[-1] - nwb.trials.goCue_start_time[0]
     trial_index = []
@@ -604,6 +604,3 @@ def create_fib_df(nwb_filename, tidy=True, adjust_time=True):
         return df_pivoted
     else:
         return df
-
-
-

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -448,6 +448,7 @@ def create_df_trials(nwb_filename, adjust_time=True):
             df.query("earned_reward == 0").query("extra_reward == 0")["reward_time_in_session"]
         )
     ), "Unrewarded trials with reward time"
+    # TODO, auto water can be delievered before choice time
 
     # Drop columns
     drop_cols += key_from_acq

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -514,6 +514,10 @@ def create_events_df(nwb_filename, adjust_time=True):
             trial_index.append(starts[-1])
     df["trial"] = trial_index
 
+    # Sanity check that the first go cue is time 0
+    gocues = df.query('event == "goCue_start_time"')
+    if (len(gocues) > 0) and (adjust_time):
+        assert np.isclose(gocues.iloc[0]['timestamps'], 0, rtol=0.01)
     return df
 
 

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -425,7 +425,9 @@ def create_df_trials(nwb_filename, adjust_time=True):
     ), "Reward before choice time"
 
     # TODO, fails because of manual rewards and auto rewards
-    # assert np.all(np.isnan(df.query('reward == 0')['reward_time_in_session'])), "Unrewarded trials with reward time"
+    # assert (
+    #    np.all(np.isnan(df.query('reward == 0')['reward_time_in_session'])
+    # ), "Unrewarded trials with reward time"
     # TODO, filter for earned rewards
 
     # Drop columns


### PR DESCRIPTION
The line that generates reference time point when calculating absolute time was modified to the start of go cue of the first trial. This is related to #49. The branch is tested in codeocean capsule. 
![image](https://github.com/user-attachments/assets/09507284-5562-4010-a790-df865951fa9d)
