### PR TITLE
Speed up df events

### DIFF
--- a/examples/make_dataframes.py
+++ b/examples/make_dataframes.py
@@ -4,6 +4,7 @@
 """
 
 import glob
+
 from aind_dynamic_foraging_data_utils import nwb_utils
 
 # List of filepaths to NWBs

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -16,8 +16,8 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from pynwb import NWBHDF5IO
 from hdmf_zarr import NWBZarrIO
+from pynwb import NWBHDF5IO
 
 # If we adjust time_in_session, adjust it to this
 SESSION_ALIGNMENT = "goCue_start_time"
@@ -530,7 +530,7 @@ def create_events_df(nwb_filename, adjust_time=True):
             "R_2_preprocessed-exp",
             "R_1_preprocessed-exp",
             "R_1_preprocessed-poly",
-            "R_2_preprocessed-bright"
+            "R_2_preprocessed-bright",
         ]
     )
     event_types -= ignore_types

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -513,6 +513,24 @@ def create_events_df(nwb_filename, adjust_time=True):
             "R_1_dff-poly",
             "R_2_dff-poly",
             "Iso_2_dff-poly",
+            "G_1_preprocessed-poly",
+            "G_2_preprocessed-bright",
+            "G_1_preprocessed-exp",
+            "G_2_preprocessed-exp",
+            "G_2_preprocessed-poly",
+            "G_1_preprocessed-bright",
+            "Iso_1_preprocessed-poly",
+            "Iso_1_preprocessed-bright",
+            "Iso_2_preprocessed-bright",
+            "Iso_2_preprocessed-exp",
+            "Iso_2_preprocessed-poly",
+            "Iso_1_preprocessed-exp",
+            "R_1_preprocessed-bright",
+            "R_2_preprocessed-poly",
+            "R_2_preprocessed-exp",
+            "R_1_preprocessed-exp",
+            "R_1_preprocessed-poly",
+            "R_2_preprocessed-bright"
         ]
     )
     event_types -= ignore_types

--- a/tests/test_aind_dynamic_foraging_data_utils.py
+++ b/tests/test_aind_dynamic_foraging_data_utils.py
@@ -37,7 +37,23 @@ class DynamicForagingTest(unittest.TestCase):
         # check that the dataframe has correct session names
         session_name = "_".join(nwb_files[0].split("/")[-1].split("_")[0:-1])
         assert df.ses_idx[0] == session_name, "{} != {}".format(session_name, df.ses_idx[0])
+    
+    def test_create_events_df(self):
+        """
+        tests the create_events_df function
+        """
+        nwb_files = glob.glob("./tests/nwb/**.nwb")
+        df_events = nwb_utils.create_events_df(nwb_files[0])
+        assert df_events
 
+    def test_create_fib_df(self):
+        """
+        tests the create_df_fip function
+        """
+        nwb_files = glob.glob("./tests/nwb/**.nwb")
+        df_fip = nwb_utils.create_fib_df(nwb_files[0])
+        assert df_fip
+        
     def test_get_time_array_with_sampling_rate(self):
         """
         tests the `get_time_array` function while passing

--- a/tests/test_aind_dynamic_foraging_data_utils.py
+++ b/tests/test_aind_dynamic_foraging_data_utils.py
@@ -37,22 +37,6 @@ class DynamicForagingTest(unittest.TestCase):
         # check that the dataframe has correct session names
         session_name = "_".join(nwb_files[0].split("/")[-1].split("_")[0:-1])
         assert df.ses_idx[0] == session_name, "{} != {}".format(session_name, df.ses_idx[0])
-    
-    def test_create_events_df(self):
-        """
-        tests the create_events_df function
-        """
-        nwb_files = glob.glob("./tests/nwb/**.nwb")
-        df_events = nwb_utils.create_events_df(nwb_files[0])
-        assert df_events
-
-    def test_create_fib_df(self):
-        """
-        tests the create_df_fip function
-        """
-        nwb_files = glob.glob("./tests/nwb/**.nwb")
-        df_fip = nwb_utils.create_fib_df(nwb_files[0])
-        assert df_fip
         
     def test_get_time_array_with_sampling_rate(self):
         """

--- a/tests/test_aind_dynamic_foraging_data_utils.py
+++ b/tests/test_aind_dynamic_foraging_data_utils.py
@@ -37,7 +37,7 @@ class DynamicForagingTest(unittest.TestCase):
         # check that the dataframe has correct session names
         session_name = "_".join(nwb_files[0].split("/")[-1].split("_")[0:-1])
         assert df.ses_idx[0] == session_name, "{} != {}".format(session_name, df.ses_idx[0])
-        
+
     def test_get_time_array_with_sampling_rate(self):
         """
         tests the `get_time_array` function while passing


### PR DESCRIPTION
df events was pulling additional G_1, R_1, G_2, R_2 as events. it was slowing down the function. PR to have the function skip them. 


full list here: 

```
            "G_1_preprocessed-poly",
            "G_2_preprocessed-bright",
            "G_1_preprocessed-exp",
            "G_2_preprocessed-exp",
            "G_2_preprocessed-poly",
            "G_1_preprocessed-bright",
            "Iso_1_preprocessed-poly",
            "Iso_1_preprocessed-bright",
            "Iso_2_preprocessed-bright",
            "Iso_2_preprocessed-exp",
            "Iso_2_preprocessed-poly",
            "Iso_1_preprocessed-exp",
            "R_1_preprocessed-bright",
            "R_2_preprocessed-poly",
            "R_2_preprocessed-exp",
            "R_1_preprocessed-exp",
            "R_1_preprocessed-poly",
            "R_2_preprocessed-bright",
```