### PR TITLE
Usability updates

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -28,6 +28,7 @@ RESPONSE_TIMING_TOLERANCE = 0.005
 # Tolerance for responses before the go cue
 CHOICE_TIMING_TOLERANCE = 0.005
 
+
 def load_nwb_from_filename(filename):
     """
     Load NWB from file, checking for HDF5 or Zarr
@@ -393,21 +394,25 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     drop_cols.append("next_goCue_start_time_in_session")
 
     # Create column with CHOICE TIMING TOLERANCE
-    df['next_goCue_start_time_in_session_tolerance'] = df['next_goCue_start_time_in_session'] - CHOICE_TIMING_TOLERANCE
-    df['goCue_start_time_in_session_tolerance'] = df['goCue_start_time_in_session'] - CHOICE_TIMING_TOLERANCE
+    df["next_goCue_start_time_in_session_tolerance"] = (
+        df["next_goCue_start_time_in_session"] - CHOICE_TIMING_TOLERANCE
+    )
+    df["goCue_start_time_in_session_tolerance"] = (
+        df["goCue_start_time_in_session"] - CHOICE_TIMING_TOLERANCE
+    )
     drop_cols.append("next_goCue_start_time_in_session_tolerance")
     drop_cols.append("goCue_start_time_in_session_tolerance")
-    
+
     for event in key_from_acq:
         event_times = events[event]
-        if event in ['left_lick_time','right_lick_time']:
-            times = '_tolerance'
+        if event in ["left_lick_time", "right_lick_time"]:
+            times = "_tolerance"
         else:
-            times = ''
+            times = ""
         df[event] = df.apply(
             lambda x: event_times[
-                (event_times >= x["goCue_start_time_in_session"+times])
-                & (event_times < x["next_goCue_start_time_in_session"+times])
+                (event_times >= x["goCue_start_time_in_session" + times])
+                & (event_times < x["next_goCue_start_time_in_session" + times])
             ],
             axis=1,
         )
@@ -468,9 +473,9 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     )
 
     # Filtering out choices greater than response window
-    slow_choice = (df["choice_time_in_trial"] > df["response_duration"] + RESPONSE_TIMING_TOLERANCE) & (
-        ~df["earned_reward"]
-    )
+    slow_choice = (
+        df["choice_time_in_trial"] > df["response_duration"] + RESPONSE_TIMING_TOLERANCE
+    ) & (~df["earned_reward"])
     df.loc[slow_choice, "choice_time_in_session"] = np.nan
     df.loc[slow_choice, "choice_time_in_trial"] = np.nan
     if np.sum(df["choice_time_in_trial"] > df["response_duration"] + RESPONSE_TIMING_TOLERANCE) > 0:

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -300,7 +300,7 @@ def create_single_df_session(nwb_filename):
     return df_session
 
 
-def create_df_trials(nwb_filename, adjust_time=True, verbose=True):
+def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     """
     Process nwb and create df_trials for every single session
 

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -1,7 +1,6 @@
 """
 Utility functions for processing dynamic foraging data.
     load_nwb_from_filename
-    unpack_metadata
     create_single_df_session_inner
     create_df_session
     create_single_df_session
@@ -44,16 +43,6 @@ def load_nwb_from_filename(filename):
     else:
         # Assuming its already an NWB
         return filename
-
-
-def unpack_metadata(nwb):
-    """
-    Unpacks metadata as a dictionary attribute, instead of a Dynamic
-    table nested inside a dictionary
-    """
-    # TODO, this should be outdated once we fix the NWB files themselves
-    nwb.metadata = nwb.scratch["metadata"].to_dataframe().iloc[0].to_dict()
-
 
 def create_single_df_session_inner(nwb):
     """
@@ -310,7 +299,7 @@ def create_single_df_session(nwb_filename):
     return df_session
 
 
-def create_df_trials(nwb_filename, adjust_time=True):
+def create_df_trials(nwb_filename, adjust_time=True, verbose=True):
     """
     Process nwb and create df_trials for every single session
 
@@ -477,18 +466,19 @@ def create_df_trials(nwb_filename, adjust_time=True):
     drop_cols += key_from_acq
     df = df.drop(columns=drop_cols)
 
-    if adjust_time:
+    if adjust_time and verbose:
         print(
             "Timestamps are adjusted such that `_in_session` timestamps start at the first go cue"
         )
     return df
 
 
-def create_events_df(nwb_filename, adjust_time=True):
+def create_events_df(nwb_filename, adjust_time=True,verbose=True):
     """
     returns a tidy dataframe of the events in the nwb file
 
     adjust_time (bool), set time of first goCue to t=0
+    verbose (bool), give warnings for adjustments
     """
 
     nwb = load_nwb_from_filename(nwb_filename)
@@ -572,14 +562,14 @@ def create_events_df(nwb_filename, adjust_time=True):
         assert np.isclose(gocues.iloc[0]["timestamps"], 0, rtol=0.01)
     # TODO, need more checks here for time alignment on trial index.
 
-    if adjust_time:
+    if adjust_time and verbose:
         print(
             "Timestamps are adjusted such that `_in_session` timestamps start at the first go cue"
         )
     return df
 
 
-def create_fib_df(nwb_filename, tidy=True, adjust_time=True):
+def create_fib_df(nwb_filename, tidy=True, adjust_time=True, verbose=True):
     """
     returns a dataframe of the FIB data in the nwb file
     if tidy, return a tidy dataframe
@@ -653,7 +643,7 @@ def create_fib_df(nwb_filename, tidy=True, adjust_time=True):
     ses_idx = subject_id + "_" + session_date
     df["ses_idx"] = ses_idx
 
-    if adjust_time:
+    if adjust_time and verbose:
         print(
             "Timestamps are adjusted such that `_in_session` timestamps start at the first go cue"
         )

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -9,10 +9,10 @@ Utility functions for processing dynamic foraging data.
     create_fib_df
 """
 
+import itertools
 import os
 import re
 import warnings
-import itertools
 
 import numpy as np
 import pandas as pd
@@ -43,6 +43,7 @@ def load_nwb_from_filename(filename):
     else:
         # Assuming its already an NWB
         return filename
+
 
 def create_single_df_session_inner(nwb):
     """
@@ -435,11 +436,11 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):
     )
 
     # Filtering out choices greater than response window
-    slow_choice = (df["choice_time_in_trial"] > df["response_duration"]) & (~df['earned_reward'])
+    slow_choice = (df["choice_time_in_trial"] > df["response_duration"]) & (~df["earned_reward"])
     df.loc[slow_choice, "choice_time_in_session"] = np.nan
     df.loc[slow_choice, "choice_time_in_trial"] = np.nan
-    if np.sum(df['choice_time_in_trial'] > df['response_duration']) > 0:
-        warnings.warn('Response time greater than minimum, something unusual happened') 
+    if np.sum(df["choice_time_in_trial"] > df["response_duration"]) > 0:
+        warnings.warn("Response time greater than minimum, something unusual happened")
 
     # Sanity checks
     rewarded_df = df.query("earned_reward")
@@ -473,7 +474,7 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):
     return df
 
 
-def create_events_df(nwb_filename, adjust_time=True,verbose=True):
+def create_events_df(nwb_filename, adjust_time=True, verbose=True):
     """
     returns a tidy dataframe of the events in the nwb file
 

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -468,20 +468,19 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     assert (
         np.isnan(rewarded_df["reward_time_in_session"]).sum() == 0
     ), "Rewarded trials without reward time"
+
     assert (
         np.isnan(rewarded_df["choice_time_in_session"]).sum() == 0
     ), "Rewarded trials without choice time"
-    # assert np.all(
-    #    rewarded_df["choice_time_in_session"] <= rewarded_df["reward_time_in_session"]
-    # ), "Reward before choice time"
-    earned_rewarded_df = rewarded_df.query("not extra_reward")
-    if not np.all(
-        earned_rewarded_df["choice_time_in_session"] <= earned_rewarded_df["reward_time_in_session"]
-    ):
+
+    earned_df = rewarded_df.query("not extra_reward")
+    if not np.all(earned_df["choice_time_in_session"] <= earned_df["reward_time_in_session"]):
         warnings.warn("Reward before choice time. This is likely due to manual rewards")
+
     assert np.all(
         rewarded_df["choice_time_in_trial"] >= 0
     ), "Rewarded trial with negative choice_time_in_trial"
+
     assert np.all(
         np.isnan(df.query("not earned_reward").query("not extra_reward")["reward_time_in_session"])
     ), "Unrewarded trials with reward time"


### PR DESCRIPTION
- Adds `verbose` option that suppresses a notification about timestamp adjustment
    - Does not suppress errors or warning
    - `nwb_utils.create_df_trials(verbose=True)`
    - `nwb_utils.create_events_df(verbose=True)`
    - `nwb_utils.create_fib_df(verbose=True)`
- removes unused `nwb_utils.unpack_metadata()`, this was a depreciated function
- Handles an edge case in create_df_trials related to choices and response windows
    - `choice_time` is set to NaN when the choice time is greater than the global value `response_duration`
    - Most of the time this just sets the choice time to NaN for intertrial_choices
    - However, rarely there are rewarded choices greater than response_duration. These appear to be timing variability with our setup, so I added a 5ms tolerance for rewards outside the response_duration tolerance. This global variable is set in the file
    - See example figure with annotation below (annotations not to scale)
    
![image1](https://github.com/user-attachments/assets/92dfa2f3-dccc-4555-b246-21efa6cc144d)


- Handles an edge case in create_df_trials related to choices just before the go cue
    - Rarely, a lick can occur just before the go cue and still trigger the reward. 
    - I added a 5ms tolerance for licks just before the go cue to be grouped into the trial corresponding to the go cue, rather than the previous trial. 
    - This means choice_time_in_trial can sometimes be up to 5ms negative
    - See example figure below
    
<img width="1044" alt="Screenshot 2025-04-09 at 7 30 31 PM" src="https://github.com/user-attachments/assets/a05f5a07-e3f0-40f3-867e-151a2a5d95c4" />

- Adds a `left_reward_type` and `right_reward_type` annotation
   - Reward types are "earned", "manual", and "auto"
   - Non rewarded trials are NaN
   
<img width="1512" alt="Screenshot 2025-04-10 at 8 46 24 AM" src="https://github.com/user-attachments/assets/2dc02a16-143d-40a0-9872-c9ca11ad8fab" />

- Updates the annotation of `earned_rewared` and `extra_reward`
   - Previously they were mutually exclusive, but its possible for a manual reward and earned reward to be on the same trial