### PR TITLE
filters for pavlovian data

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -155,14 +155,9 @@ def get_all_df_for_nwb(filename_sessions, loc="../scratch/", interested_channels
         df_session = nwb_utils.create_df_session(nwb)
         df_session["ses_idx"] = ses_idx
 
-        try:
-            # trials
-            df_ses_trials = nwb_utils.create_df_trials(nwb)
-            df_ses_trials["ses_idx"] = ses_idx
-            df_trials = pd.concat([df_trials, df_ses_trials], axis=0)
-        except AssertionError as e:
-            print(f"Skipping {ses_idx} due to assertion error: {e}")
-            continue  # move to the next mouse
+        df_ses_trials = nwb_utils.create_df_trials(nwb)
+        df_ses_trials["ses_idx"] = ses_idx
+        df_trials = pd.concat([df_trials, df_ses_trials], axis=0)
 
         # FIP
         df_ses_fip = nwb_utils.create_fib_df(nwb, tidy=True)
@@ -188,7 +183,7 @@ def get_all_df_for_nwb(filename_sessions, loc="../scratch/", interested_channels
         # correct fix is lickspout_y == lickspout_y1 == lickspout_y2
         # and always have lickspout_y1,y2.
         # I will fix this at a later date.... code to fix this is below
-        df_trials = df_trials.reset_index(drop=True)
+        df_trials = df_trials.reset_index()
         df_trials.to_csv(loc + "df_trials.csv", index=False)
 
 

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -155,6 +155,7 @@ def get_all_df_for_nwb(filename_sessions, loc="../scratch/", interested_channels
         df_session = nwb_utils.create_df_session(nwb)
         df_session["ses_idx"] = ses_idx
 
+        # trials
         df_ses_trials = nwb_utils.create_df_trials(nwb)
         df_ses_trials["ses_idx"] = ses_idx
         df_trials = pd.concat([df_trials, df_ses_trials], axis=0)

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -42,13 +42,22 @@ def get_subject_assets(subject_id, processed=True):
         host="api.allenneuraldynamics.org", database="metadata_index", collection="data_assets"
     )
 
+    task_filter = {
+        "$or": [
+            {"session": None},
+            {
+                "session": {"$exists": True, "$ne": None},
+                "session.session_type": {"$regex": "^(Uncoupled|Coupled)( Without)? Baiting$"}
+            }
+        ]
+    }
     # Query based on subject id
     if processed:
         results = pd.DataFrame(
             client.retrieve_docdb_records(
                 filter_query={
                     "name": {"$regex": "^behavior_{}_.*processed_[0-9-_]*$".format(subject_id)},
-                    "session.session_type": {"$ne": "PavlovianConditioning"},
+                    **task_filter
                 }
             )
         )
@@ -57,7 +66,7 @@ def get_subject_assets(subject_id, processed=True):
             client.retrieve_docdb_records(
                 filter_query={
                     "name": {"$regex": "^behavior_{}_[0-9-_]*$".format(subject_id)},
-                    "session.session_type": {"$ne": "PavlovianConditioning"},
+                    **task_filter
                 }
             )
         )

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -47,14 +47,18 @@ def get_subject_assets(subject_id, processed=True):
         results = pd.DataFrame(
             client.retrieve_docdb_records(
                 filter_query={
-                    "name": {"$regex": "^behavior_{}_.*processed_[0-9-_]*$".format(subject_id)}
+                    "name": {"$regex": "^behavior_{}_.*processed_[0-9-_]*$".format(subject_id)},
+                    "session.session_type" : { "$ne":"PavlovianConditioning" },
+
                 }
             )
         )
     else:
         results = pd.DataFrame(
             client.retrieve_docdb_records(
-                filter_query={"name": {"$regex": "^behavior_{}_[0-9-_]*$".format(subject_id)}}
+                filter_query={"name": {"$regex": "^behavior_{}_[0-9-_]*$".format(subject_id)}, 
+                            "session.session_type" : { "$ne":"PavlovianConditioning" },
+                            }
             )
         )
 

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -47,7 +47,7 @@ def get_subject_assets(subject_id, processed=True):
             {"session": None},
             {
                 "session": {"$exists": True, "$ne": None},
-                "session.session_type": {"$regex": "^(Uncoupled|Coupled)( Without)? Baiting$"}
+                "session.session_type": {"$regex": "^(Uncoupled|Coupled)( Without)? Baiting"}
             }
         ]
     }


### PR DESCRIPTION
co_utils.get_subject_assets returns sessions that are pavlovian task because they're named similarly to dynamic foraging task. 

i'm filtering them out. 

quick one line addition to check for the session_type and that it isn't pavlovian. 
