### PR TITLE
Clarifies start_time as bonsai_start_time, uses goCue to index events into trials

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -575,11 +575,11 @@ def create_events_df(nwb_filename, adjust_time=True, verbose=True):
     df = df.dropna(subset="timestamps").reset_index(drop=True)
 
     # Add trial index for each event
-    trial_starts = nwb.trials.start_time[:] - t0
-    last_stop = nwb.trials.stop_time[-1] - t0
+    trial_starts = nwb.trials.goCue_start_time[:] - t0
+    last_stop = np.inf
     trial_index = []
     for index, e in df.iterrows():
-        starts = np.where(e.timestamps > trial_starts)[0]
+        starts = np.where(e.timestamps >= trial_starts)[0]
         if len(starts) == 0:
             trial_index.append(-1)
         elif e.timestamps > last_stop:

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -344,6 +344,7 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     # Adjust for gaps in trial start/stop, and use the last stop time
     last_stop = df.iloc[-1]["stop_time"]
     df["stop_time"] = df["start_time"].shift(-1, fill_value=last_stop)
+    df = df.rename(columns={"start_time": "bonsai_start_time", "stop_time": "bonsai_stop_time"})
 
     # We skip these columns because they are how long the valve is open
     # not the times at which the valves were opened
@@ -532,8 +533,7 @@ def create_events_df(nwb_filename, adjust_time=True, verbose=True):
 
     # Filter out all fibers
     event_types = {
-        k for k in event_types
-        if not any(k.startswith(prefix) for prefix in FIP_prefixes)
+        k for k in event_types if not any(k.startswith(prefix) for prefix in FIP_prefixes)
     }
 
     event_types -= {"FIP_falling_time", "FIP_rising_time"}
@@ -615,7 +615,7 @@ def create_fib_df(nwb_filename, tidy=True, adjust_time=True, verbose=True):
     # Build list of all FIB events in NWB file
     nwb_data = nwb.acquisition
     if len(nwb.processing):
-        nwb_data = nwb.acquisition | nwb.processing['fiber_photometry'].data_interfaces
+        nwb_data = nwb.acquisition | nwb.processing["fiber_photometry"].data_interfaces
 
     event_types = set(nwb_data.keys())
 
@@ -624,10 +624,7 @@ def create_fib_df(nwb_filename, tidy=True, adjust_time=True, verbose=True):
     FIP_prefixes = [f"{c}_{f}" for c in channels for f in fibers]
 
     # Filter out all fibers
-    event_types = {
-        k for k in event_types
-        if any(k.startswith(prefix) for prefix in FIP_prefixes)
-    }
+    event_types = {k for k in event_types if any(k.startswith(prefix) for prefix in FIP_prefixes)}
 
     event_types.add("FIP_falling_time")
     event_types.add("FIP_rising_time")


### PR DESCRIPTION
- Renames 'start_time' to 'bonsai_start_time' to clarify that this refers to an internal timepoint not a stimulus event
- Renames 'stop_time' to 'bonsai_stop_time' to clarify that this refers to an internal timepoint not a stimulus event
- Updates `create_events_df` to annotate events with the current trial using the most recent go-cue, not the bonsai_start/stop_time. This brings create_events_df into consistency with how create_trials_df annotates licks
- resolves #81 
- Some linting updates

Updated df_events
<img width="934" alt="Screenshot 2025-04-29 at 1 59 44 PM" src="https://github.com/user-attachments/assets/6f77ece8-45a7-4603-9b13-a98d4254f989" />

Old df_events for reference
<img width="934" alt="Screenshot 2025-04-29 at 2 00 55 PM" src="https://github.com/user-attachments/assets/b6703a54-fc03-4ae1-932e-2be664940d17" />


