### PR TITLE
Prevents extrapolation when computing event triggered response

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/alignment.py
+++ b/src/aind_dynamic_foraging_data_utils/alignment.py
@@ -383,13 +383,16 @@ def event_triggered_response(  # noqa C901
         )
         data_dict = {"time": t_array}
 
+        # Add one extra timestep in the data outside the t_window
+        dt = np.diff(data[t].values).mean()
+
         # iterate over all event times
         data_reindexed = data.set_index(t, inplace=False)
 
         for event_number, event_time in enumerate(np.array(event_times)):
             # get a slice of the input data surrounding each event time
             data_slice = data_reindexed[y].loc[
-                event_time + t_start : event_time + t_end
+                event_time + t_start - dt : event_time + t_end + dt
             ]  # noqa: E501
 
             # if the slice is empty, we will fill it with NaNs

--- a/src/aind_dynamic_foraging_data_utils/alignment.py
+++ b/src/aind_dynamic_foraging_data_utils/alignment.py
@@ -384,6 +384,8 @@ def event_triggered_response(  # noqa C901
         data_dict = {"time": t_array}
 
         # Add one extra timestep in the data outside the t_window
+        # this ensures we are not extrapolating at the edge of t_window
+        # and instead doing interpolation.
         dt = np.diff(data[t].values).mean()
 
         # iterate over all event times

--- a/src/aind_dynamic_foraging_data_utils/alignment.py
+++ b/src/aind_dynamic_foraging_data_utils/alignment.py
@@ -422,15 +422,16 @@ def event_triggered_response(  # noqa C901
                         data_slice.index.values, x_data.index.values, x_data.values
                     )
 
-                    # Add to data dict as normal
+                    interpolated = np.interp(
+                        data_dict["time"],
+                        data_slice.index - event_time,
+                        data_slice.values,
+                    )
+                    # Screen for extrapolation points
+                    interpolated[data_dict["time"] < np.min(data_slice.index - event_time)] = np.nan
+                    interpolated[data_dict["time"] > np.max(data_slice.index - event_time)] = np.nan
                     data_dict.update(
-                        {
-                            "event_{}_t={}".format(event_number, event_time): np.interp(
-                                data_dict["time"],
-                                data_slice.index - event_time,
-                                data_slice.values,
-                            )
-                        }
+                        {"event_{}_t={}".format(event_number, event_time): interpolated}
                     )
             else:
                 # update our dictionary to have a new key defined as
@@ -438,15 +439,15 @@ def event_triggered_response(  # noqa C901
                 # a value that includes an array that represents the
                 # sliced data around the current event, interpolated
                 # on the linearly spaced time array
-                data_dict.update(
-                    {
-                        "event_{}_t={}".format(event_number, event_time): np.interp(
-                            data_dict["time"],
-                            data_slice.index - event_time,
-                            data_slice.values,
-                        )
-                    }
+                interpolated = np.interp(
+                    data_dict["time"],
+                    data_slice.index - event_time,
+                    data_slice.values,
                 )
+                # Screen for extrapolation points
+                interpolated[data_dict["time"] < np.min(data_slice.index - event_time)] = np.nan
+                interpolated[data_dict["time"] > np.max(data_slice.index - event_time)] = np.nan
+                data_dict.update({"event_{}_t={}".format(event_number, event_time): interpolated})
 
         # define a wide dataframe as a dataframe of the above compiled dictionary  # NOQA E501
         wide_etr = pd.DataFrame(data_dict)


### PR DESCRIPTION
Previously if the event_times +/- time_window were outside the signal timepoints, the code will extrapolate instead of interpolate. This adds a check for extrapolated timepoints and sets them to NaN. This case should arise rarely in normal operations, and is mostly a screen against user error. 

resolves #78 
