### PR TITLE
add s3 filetype. can be opened with ZarrIO in the analysis architecture

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -36,17 +36,12 @@ def load_nwb_from_filename(filename):
     """
 
     if type(filename) is str:
-        if os.path.isdir(filename):
+        if os.path.isdir(filename) or (filename.startswith('s3://') and filename.endswith('.nwb')):
             io = NWBZarrIO(filename, mode="r")
             nwb = io.read()
             return nwb
         elif os.path.isfile(filename):
             io = NWBHDF5IO(filename, mode="r")
-            nwb = io.read()
-            return nwb
-        elif filename.startswith('s3://') and filename.endswith('.nwb'):
-            # s3 file can be opend with ZarrIO in analysis architecture
-            io = NWBZarrIO(filename, mode="r")
             nwb = io.read()
             return nwb
         else:


### PR DESCRIPTION
s3 filetypes need to be opened with ZarrIO. This is used in the analysis architecture, where filename are given as the direct s3 path rather than an attached data asset. 

Adding this case for load_nwb_from_filename(filename):