### PR TITLE
Allow users to modify docdb projection with input parameter

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -51,7 +51,13 @@ def get_subject_assets(subject_id, **kwargs):
 
 
 def get_assets(  # NOQA: C901
-    subjects=[], processed=True, task=[], modality=["behavior"], stage=[], extra_filter={}, input_projection = {}
+    subjects=[],
+    processed=True,
+    task=[],
+    modality=["behavior"],
+    stage=[],
+    extra_filter={},
+    input_projection={},
 ):
     """
     Returns the docDB results for a subject. If duplicate entries exist, take the last
@@ -133,7 +139,7 @@ def get_assets(  # NOQA: C901
             "session_name": 1,
             "external_links": 1,
             "subject.subject_id": 1,
-            **input_projection
+            **input_projection,
         }
     else:
         subject_filter = {


### PR DESCRIPTION
Users can pass in a dictionary of projection parameters that are added to the projection passed to docdb. This lets users dynamically querying docdb