### PR TITLE
Enhance create_df_events with ignore parameter

### DIFF
--- a/examples/make_dataframes.py
+++ b/examples/make_dataframes.py
@@ -1,6 +1,6 @@
 """
-    This is an example script to extract dataframes
-    from an NWB file
+This is an example script to extract dataframes
+from an NWB file
 """
 
 import glob

--- a/src/aind_dynamic_foraging_data_utils/alignment.py
+++ b/src/aind_dynamic_foraging_data_utils/alignment.py
@@ -1,10 +1,10 @@
 """
-    Tools for aligning continuous and discrete events
-    functions:
-    get_time_array
-    slice_inds_and_offsets
-    index_of_nearest_value
-    event_triggered_response
+Tools for aligning continuous and discrete events
+functions:
+get_time_array
+slice_inds_and_offsets
+index_of_nearest_value
+event_triggered_response
 """
 
 import numpy as np

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -423,10 +423,8 @@ def get_foraging_model_info(
             or df.get("latent_variables") is None
             or df["latent_variables"][0] is None
         ):
-            print(
-                f"Skipping {sess_idx}. Fitted model {model_name}, \
-                 params, or latent variables not found for this session"
-            )
+            print(f"Skipping {sess_idx}. Fitted model {model_name}, \
+                 params, or latent variables not found for this session")
             continue  # skip if no model fits is found for this session
 
         # Fitted parameters
@@ -449,10 +447,8 @@ def get_foraging_model_info(
         choice_prob = np.array(fitted_latent["choice_prob"]).astype(float)
 
         if len(mouse_choice_idx) != np.shape(choice_prob)[1]:
-            print(
-                f"Skipping {sess_idx}. Fitted model {model_name} \
-                  does not have matching number of trials"
-            )
+            print(f"Skipping {sess_idx}. Fitted model {model_name} \
+                  does not have matching number of trials")
             continue  # skip if the fitted choices do not match number of trials
 
         df_trials_fm.loc[mouse_choice_idx, "L_prob"] = choice_prob[0, :]

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -12,12 +12,12 @@ Utility functions for processing dynamic foraging data.
 import os
 import re
 import warnings
+from datetime import date
 
 import numpy as np
 import pandas as pd
 from hdmf_zarr import NWBZarrIO
 from pynwb import NWBHDF5IO
-from datetime import date
 
 # If we adjust time_in_session, adjust it to this
 SESSION_ALIGNMENT = "goCue_start_time"
@@ -491,10 +491,8 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     rewarded_df = df.query("earned_reward")
     if not np.isnan(rewarded_df["reward_time_in_session"]).sum() == 0:
         if date.fromisoformat(session_date) <= manual_reward_date_cutoff:
-            warnings.warn(
-                "Rewarded trials without reward time. \
-                This is likely due to manual rewards not being recorded in sessions from 2024"
-            )
+            warnings.warn("Rewarded trials without reward time. \
+                This is likely due to manual rewards not being recorded in sessions from 2024")
         else:
             raise AssertionError("Rewarded trials without reward time")
 
@@ -505,10 +503,8 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     earned_df = rewarded_df.query("not extra_reward")
     if not np.all(earned_df["choice_time_in_session"] <= earned_df["reward_time_in_session"]):
         if date.fromisoformat(session_date) <= manual_reward_date_cutoff:
-            warnings.warn(
-                "Reward before choice time. \
-                This is likely due to manual rewards not being recorded in sessions from 2024"
-            )
+            warnings.warn("Reward before choice time. \
+                This is likely due to manual rewards not being recorded in sessions from 2024")
         else:
             raise AssertionError("Reward before choice time")
 
@@ -555,10 +551,7 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     return df
 
 
-def create_df_events(nwb_filename, 
-                     adjust_time=True, 
-                     verbose=True,
-                     ignore=['sniff_detector']):
+def create_df_events(nwb_filename, adjust_time=True, verbose=True, ignore=["sniff_detector"]):
     """
     returns a tidy dataframe of the events in the nwb file
 
@@ -584,11 +577,11 @@ def create_df_events(nwb_filename,
     }
 
     event_types -= {"FIP_falling_time", "FIP_rising_time"}
-                         
+
     # Filter out other streams
     for event_field in ignore:
         event_types -= {event_field}
-        
+
     # Determine time 0 as first go Cue
     if adjust_time:
         t0 = nwb.trials[SESSION_ALIGNMENT][0]

--- a/tests/test_aind_dynamic_foraging_data_utils.py
+++ b/tests/test_aind_dynamic_foraging_data_utils.py
@@ -1,10 +1,10 @@
 """Testing for utility functions for processing dynamic foraging data."""
 
+import glob
 import unittest
 
 import numpy as np
 import pandas as pd
-import glob
 
 from src.aind_dynamic_foraging_data_utils import alignment, nwb_utils
 


### PR DESCRIPTION
Added 'ignore' parameter to create_df_events function to allow exclusion of specified event fields during dataframe creation.

This is useful if, for example, the nwb has continuous variables (sniffing, etc.), that are not needed for general task analysis.