### PR TITLE
fix non-numeric values in `delay_start_time` and allow users to suppress assertion errors

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -356,8 +356,8 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     skip_cols = ["right_valve_open_time", "left_valve_open_time"]
 
     # Manual fix for delay_start_time
-    if 'delay_start_time' in df:
-        df['delay_start_time'] = pd.to_numeric(df['delay_start_time'], errors='coerce')
+    if "delay_start_time" in df:
+        df["delay_start_time"] = pd.to_numeric(df["delay_start_time"], errors="coerce")
 
     # compute times relative to start of trial and start of session
     t0 = nwb.trials[SESSION_ALIGNMENT][0]

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -335,7 +335,11 @@ def create_df_trials(  # NOQA C901
     nwb = load_nwb_from_filename(nwb_filename)
 
     # Parse subject and session_date
-    if nwb.session_id.startswith("behavior") or nwb.session_id.startswith("FIP"):
+    if (
+        nwb.session_id.startswith("behavior")
+        or nwb.session_id.startswith("FIP")
+        or nwb.session_id.startswith("ecephys")
+    ):
         splits = nwb.session_id.split("_")
         subject_id = splits[1]
         session_date = splits[2]

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -507,11 +507,10 @@ def create_df_trials(
                 "Rewarded trials without reward time. \
                 This is likely due to manual rewards not being recorded in sessions from 2024"
             )
+        elif ignore_errors:
+            warnings.warn("Rewarded trials without reward time")
         else:
-            if ignore_errors:
-                warnings.warn("Rewarded trials without reward time")
-            else:
-                raise AssertionError("Rewarded trials without reward time")
+            raise AssertionError("Rewarded trials without reward time")
 
     assert (
         np.isnan(rewarded_df["choice_time_in_session"]).sum() == 0
@@ -524,11 +523,10 @@ def create_df_trials(
                 "Reward before choice time. \
                 This is likely due to manual rewards not being recorded in sessions from 2024"
             )
+        elif ignore_errors:
+            warnings.warn("Reward before choice time")
         else:
-            if ignore_errors:
-                warnings.warn("Reward before choice time")
-            else:
-                raise AssertionError("Reward before choice time")
+            raise AssertionError("Reward before choice time")
 
     assert np.all(
         rewarded_df["choice_time_in_trial"] >= -CHOICE_TIMING_TOLERANCE
@@ -544,11 +542,10 @@ def create_df_trials(
                         this is likely because extra_rewards are not recorded",
                 UserWarning,
             )
+        elif ignore_errors:
+            warnings.warn("Unrewarded trials with reward time")
         else:
-            if ignore_errors:
-                warnings.warn("Unrewarded trials with reward time")
-            else:
-                raise AssertionError("Unrewarded trials with reward time")
+            raise AssertionError("Unrewarded trials with reward time")
 
     # Drop columns
     drop_cols += key_from_acq

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -355,6 +355,10 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
     # not the times at which the valves were opened
     skip_cols = ["right_valve_open_time", "left_valve_open_time"]
 
+    # Manual fix for delay_start_time
+    if 'delay_start_time' in df:
+        df['delay_start_time'] = pd.to_numeric(df['delay_start_time'], errors='coerce')
+
     # compute times relative to start of trial and start of session
     t0 = nwb.trials[SESSION_ALIGNMENT][0]
     drop_cols = []

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -310,9 +310,9 @@ def create_single_df_session(nwb_filename):
     return df_session
 
 
-def create_df_trials(
+def create_df_trials(  # NOQA C901
     nwb_filename, adjust_time=True, verbose=True, ignore_errors=False
-):  # NOQA C901
+):
     """
     Process nwb and create df_trials for every single session
 

--- a/src/aind_dynamic_foraging_data_utils/nwb_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/nwb_utils.py
@@ -310,13 +310,17 @@ def create_single_df_session(nwb_filename):
     return df_session
 
 
-def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
+def create_df_trials(
+    nwb_filename, adjust_time=True, verbose=True, ignore_errors=False
+):  # NOQA C901
     """
     Process nwb and create df_trials for every single session
 
     ARGS:
     nwb_filename (str or NWB object), the session to extract the trials from
     adjust_time (bool) if true, adjust t0 to be the first gocue
+    ignore_errors(bool) if true, ignore AssertionErrors about data quality.
+        Otherwise raise a warning about data quality
 
     RETURNS:
     A pandas dataframe containing the columns of nwb.trials plus:
@@ -504,7 +508,10 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
                 This is likely due to manual rewards not being recorded in sessions from 2024"
             )
         else:
-            raise AssertionError("Rewarded trials without reward time")
+            if ignore_errors:
+                warnings.warn("Rewarded trials without reward time")
+            else:
+                raise AssertionError("Rewarded trials without reward time")
 
     assert (
         np.isnan(rewarded_df["choice_time_in_session"]).sum() == 0
@@ -518,7 +525,10 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
                 This is likely due to manual rewards not being recorded in sessions from 2024"
             )
         else:
-            raise AssertionError("Reward before choice time")
+            if ignore_errors:
+                warnings.warn("Reward before choice time")
+            else:
+                raise AssertionError("Reward before choice time")
 
     assert np.all(
         rewarded_df["choice_time_in_trial"] >= -CHOICE_TIMING_TOLERANCE
@@ -535,7 +545,10 @@ def create_df_trials(nwb_filename, adjust_time=True, verbose=True):  # NOQA C901
                 UserWarning,
             )
         else:
-            raise AssertionError("Unrewarded trials with reward time")
+            if ignore_errors:
+                warnings.warn("Unrewarded trials with reward time")
+            else:
+                raise AssertionError("Unrewarded trials with reward time")
 
     # Drop columns
     drop_cols += key_from_acq

--- a/tests/test_aind_dynamic_foraging_data_utils.py
+++ b/tests/test_aind_dynamic_foraging_data_utils.py
@@ -35,7 +35,10 @@ class DynamicForagingTest(unittest.TestCase):
         # create a dataframe for one nwb file
         df = nwb_utils.create_df_trials(nwb_files[0])
         # check that the dataframe has correct session names
-        session_name = "_".join(nwb_files[0].split("/")[-1].split("_")[0:-1])
+        if "behavior" in nwb_files[0]:
+            session_name = "_".join(nwb_files[0].split("/")[-1].split("_")[1:-1])
+        else:
+            session_name = "_".join(nwb_files[0].split("/")[-1].split("_")[0:-1])
         assert df.ses_idx[0] == session_name, "{} != {}".format(session_name, df.ses_idx[0])
 
     def test_get_time_array_with_sampling_rate(self):


### PR DESCRIPTION
This PR resolves #148 by handling two cases. A third case is left as is, since nwb files without trials tables cannot produced a trials dataframe. 

### non-numeric values in `delay_start_time`
- Replaces #131 
- resolves #149 
- Makes a targeted coercion of `delay_start_time` which can have `none` as a string 

### allow users to suppress assertion errors
- replaces #133, which had #131 mixed in
- resolves #132 
- Allows users to load the trials table and ignore AssertionErrors. I strongly recommend this not to be used if we dont understand why the data had problems to begin with. 

### AttributeError: 'NoneType' object has no attribute 'to_dataframe'
 the problem is the NWB files in question do not have trials tables. So all we can do is throw an error. I'm not sure a custom error would be more informative than the attribute error currently thrown. I suggest keeping the status quo


## Unrelated session string parsing
Fixing this issue here as well. Replaces #126 