### PR TITLE
extending docdb query to search either metadata v2 or metadata v1, and to search for refactored DF assets

### DIFF
--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -334,7 +334,11 @@ def get_assets_v2(  # NOQA C901
 
         # Filter by Stage
         if len(stage) > 0:
-            stage_filter = {"acquisition.stimulus_epochs.curriculum_status": {"$in": stage}}
+            stage_filter = {
+                "acquisition.stimulus_epochs.performance_metrics.output_parameters.stage_name": {
+                    "$in": stage
+                }
+            }
         else:
             stage_filter = {}
 

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -315,29 +315,26 @@ def get_assets_v2(
         print("No results found for {}".format(subjects))
         return
 
-    # TODO, look for duplicate entries
     # look for duplicate entries, taking the last by processing time
-    # results["session_name"] = [x.split("_processed")[0] for x in results["name"]]
-    # results = results.sort_values(by="name")
-    # results_no_duplicates = results.drop_duplicates(subset="session_name", keep="last").copy()
+    results["session_name"] = [x.split("_processed")[0] for x in results["name"]]
+    results = results.sort_values(by="name")
+    results_no_duplicates = results.drop_duplicates(subset="session_name", keep="last").copy()
 
     ## If there were duplicates, make a warning and print the duplicates
-    # if len(results) != len(results_no_duplicates):
-    #    duplicated = results[results.duplicated(subset="session_name", keep=False)]
-    #    warnings.warn("Duplicate session entries in docDB")
-    #    for index, row in duplicated.iterrows():
-    #        print("duplicated: {}".format(row["name"]))
+    if len(results) != len(results_no_duplicates):
+        duplicated = results[results.duplicated(subset="session_name", keep=False)]
+        warnings.warn("Duplicate session entries in docDB")
+        for index, row in duplicated.iterrows():
+            print("duplicated: {}".format(row["name"]))
+    results_no_duplicates = results
 
-    # TODO make code ocean ID a column
-    ## Make code ocean ID a column
-    # results_no_duplicates["code_ocean_asset_id"] = [
-    #    link["Code Ocean"][0] if ("Code Ocean" in link) and (len(link["Code Ocean"]) > 0) else ""
-    #    for link in results_no_duplicates["external_links"]
-    # ]
+    # Make code ocean ID a column
+    results_no_duplicates["code_ocean_asset_id"] = [
+        link["Code Ocean"][0] if ("Code Ocean" in link) and (len(link["Code Ocean"]) > 0) else ""
+        for link in results_no_duplicates["other_identifiers"]
+    ]
 
-    # return results_no_duplicates.reset_index(drop=True)
-
-    return results
+    return results_no_duplicates.reset_index(drop=True)
 
 
 def generate_data_asset_attach_params(data_asset_IDs, mount_point=None):
@@ -346,6 +343,11 @@ def generate_data_asset_attach_params(data_asset_IDs, mount_point=None):
     data_asset_IDs:  list of data asset IDs, i.e. the 16 hash string for the data asset in CO.
     mount_point: the mount point (folder) for the data asset. Default is None.
     """
+    warnings.warn(
+        "generate_data_assets_attach_params is Deprecated. "
+        + "We no longer recommend programmatically attaching assets. "
+        + "Instead attach manually or use the s3 location directly"
+    )
     data_assets = []
     for ID in data_asset_IDs:
         if mount_point:
@@ -368,7 +370,11 @@ def attach_data(data_asset_IDs, token_name="CUSTOM_KEY"):
     results = get_subject_assets(my_id)
     co_assets = attach_data(results['code_ocean_asset_id'].values)
     """
-
+    warnings.warn(
+        "attach_data is deprecated. "
+        + "We no longer recommend programmatically attaching assets. "
+        + "Instead attach manually or use the s3 location directly"
+    )
     # Check for too many assets
     if len(data_asset_IDs) > 100:
         warnings.warn(
@@ -418,6 +424,11 @@ def check_data_assets(co_assets, data_asset_IDs):
     This function is delicate because CO is strange about "ready",
     but its a useful quick check
     """
+    warnings.warn(
+        "check_data_assets is deprecated. "
+        + "We no longer recommend programmatically attaching assets. "
+        + "Instead attach manually or use the s3 location directly"
+    )
     if all([x.ready for x in co_assets if x.id in data_asset_IDs]):
         print("all data assets are ready")
     else:

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -236,6 +236,7 @@ def get_assets_v2(
     #   "Uncoupled Without Baiting",
     #   "Coupled Without Baiting",
     # TODO, should update this section to filter for v1 or v2 or both acquisition systems
+    # for v1, acquisition.acquisition_type will contain the task name
     if len(task) > 0:
         task_filter = {
             "acquisition.stimulus_epochs.training_protocol_name": {"$in": task},
@@ -247,10 +248,29 @@ def get_assets_v2(
         }
 
     # Filter by Stage
+    # TODO, if acquisition is v1, then need to check in:
+    # acquisition.stimulus_epochs.performance_metrics.output_parameters.task_parameters.stage_in_use
     if len(stage) > 0:
         stage_filter = {"acquisition.stimulus_epochs.curriculum_status": {"$in": stage}}
     else:
         stage_filter = {}
+
+    # TODO, need to update this
+    ## What information to return
+    #if (len(input_projection) == 0) & len(subjects) == 0:
+    #    projection = {
+    #        "name": 1,
+    #        "_id": 1,
+    #        "session": 1,
+    #        "session_name": 1,
+    #        "external_links": 1,
+    #        "subject.subject_id": 1,
+    #        **input_projection,
+    #    }
+    #elif len(input_projection) > 0:
+    #    projection = input_projection
+    #else:
+    #    projection = None
 
     # extra_filter,
     results = pd.DataFrame(

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -120,6 +120,11 @@ def get_assets_v1(  # NOQA: C901
     Example
     results = get_assets_v1(subjects=[my_id])
     """
+    warnings.warn(
+        "Using metadata v1 will be phased out, switch your workflows now to metadata v2",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     # Create metadata client
     client = MetadataDbClient(
         host="api.allenneuraldynamics.org", database="metadata_index", collection="data_assets"
@@ -397,7 +402,9 @@ def generate_data_asset_attach_params(data_asset_IDs, mount_point=None):
     warnings.warn(
         "generate_data_assets_attach_params is Deprecated. "
         + "We no longer recommend programmatically attaching assets. "
-        + "Instead attach manually or use the s3 location directly"
+        + "Instead attach manually or use the s3 location directly",
+        category=DeprecationWarning,
+        stacklevel=2,
     )
     data_assets = []
     for ID in data_asset_IDs:
@@ -422,10 +429,13 @@ def attach_data(data_asset_IDs, token_name="CUSTOM_KEY"):
     co_assets = attach_data(results['code_ocean_asset_id'].values)
     """
     warnings.warn(
-        "attach_data is deprecated. "
+        "attach_data is Deprecated. "
         + "We no longer recommend programmatically attaching assets. "
-        + "Instead attach manually or use the s3 location directly"
+        + "Instead attach manually or use the s3 location directly",
+        category=DeprecationWarning,
+        stacklevel=2,
     )
+
     # Check for too many assets
     if len(data_asset_IDs) > 100:
         warnings.warn(
@@ -476,9 +486,11 @@ def check_data_assets(co_assets, data_asset_IDs):
     but its a useful quick check
     """
     warnings.warn(
-        "check_data_assets is deprecated. "
+        "check_data_assets is Deprecated. "
         + "We no longer recommend programmatically attaching assets. "
-        + "Instead attach manually or use the s3 location directly"
+        + "Instead attach manually or use the s3 location directly",
+        category=DeprecationWarning,
+        stacklevel=2,
     )
     if all([x.ready for x in co_assets if x.id in data_asset_IDs]):
         print("all data assets are ready")

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -244,7 +244,7 @@ def get_assets_v2(  # NOQA C901
     task=[],
     modality=["behavior"],
     stage=[],
-    acquisition_version=["v2"],
+    acquisition_version=["v1", "v2"],
     extra_filter={},
     input_projection={},
 ):

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -195,7 +195,7 @@ def get_assets_v1(  # NOQA: C901
     return results_no_duplicates.reset_index(drop=True)
 
 
-def get_assets_v2(
+def get_assets_v2(  # NOQA C901
     subjects=[],
     processed=True,
     task=[],
@@ -245,9 +245,8 @@ def get_assets_v2(
         # Filter by Stage
         if len(stage) > 0:
             stage_filter = {
-                "acquisition.stimulus_epochs.performance_metrics.output_parameters.task_parameters.stage_in_use": {
-                    "$in": stage
-                }
+                "acquisition.stimulus_epochs.performance_metrics"
+                + ".output_parameters.task_parameters.stage_in_use": {"$in": stage}
             }
         else:
             stage_filter = {}
@@ -321,7 +320,7 @@ def get_assets_v2(
     results = results.sort_values(by="name")
     results_no_duplicates = results.drop_duplicates(subset="session_name", keep="last").copy()
 
-    ## If there were duplicates, make a warning and print the duplicates
+    # If there were duplicates, make a warning and print the duplicates
     if len(results) != len(results_no_duplicates):
         duplicated = results[results.duplicated(subset="session_name", keep=False)]
         warnings.warn("Duplicate session entries in docDB")

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -241,7 +241,7 @@ def get_assets_v2(
         ]
     task_filter = {"acquisition.acquisition_type": {"$in": task}}
 
-    # stage_filter,
+    # stage_filter, acquisition.stimulus_epochs.curriculum_status
     # extra_filter,
     # projection=projection,
     results = pd.DataFrame(client.retrieve_docdb_records(

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -289,6 +289,7 @@ def get_assets_v2(
             "name": 1,
             "_id": 1,
             "subject.subject_id": 1,
+            "other_identifiers": 1,
             **input_projection,
         }
     elif len(input_projection) > 0:

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -22,16 +22,18 @@ from codeocean.data_asset import DataAssetAttachParams
 
 from aind_dynamic_foraging_data_utils import nwb_utils
 
-def get_assets(metadata_version='v1',**kwargs):
-    '''
+
+def get_assets(metadata_version="v1", **kwargs):
+    """
     Top level function that queries either docdb v1 or v2
-    '''
+    """
     if metadata_version == "v1":
         return get_assets_v1(**kwargs)
     elif metadata_version == "v2":
         return get_assets_v2(**kwargs)
     else:
         raise ValueError(f"Unknown input argument {metadata_version}")
+
 
 def get_subject_assets(subject_id, **kwargs):
     """
@@ -192,20 +194,19 @@ def get_assets_v1(  # NOQA: C901
 
     return results_no_duplicates.reset_index(drop=True)
 
+
 def get_assets_v2(
     subjects=[],
     processed=True,
     task=[],
     modality=["behavior"],
     stage=[],
-    acquisition_version=['v1','v2'],
+    acquisition_version=["v2"],
     extra_filter={},
     input_projection={},
 ):
     # Create metadata client
-    client = MetadataDbClient(
-        host="api.allenneuraldynamics.org", version="v2" 
-    )
+    client = MetadataDbClient(host="api.allenneuraldynamics.org", version="v2")
 
     # Query based on subject id
     if len(subjects) == 0:
@@ -228,30 +229,73 @@ def get_assets_v2(
             modality_filter["$and"].append({"data_description.modality.abbreviation": m})
     else:
         modality_filter = {}
-    
-    # Filter by task
-    # TODO, parse by acquisition version here ?
-    if len(task) == 0:
-        task = [
-            "Uncoupled Baiting",
-            "Coupled Baiting",
-            "Uncoupled Without Baiting",
-            "Coupled Without Baiting",
-            "AindDynamicForaging"
-        ]
-    task_filter = {"acquisition.acquisition_type": {"$in": task}}
 
-    # stage_filter, acquisition.stimulus_epochs.curriculum_status
-    # extra_filter,
-    # projection=projection,
-    results = pd.DataFrame(client.retrieve_docdb_records(
-        filter_query={
-            **subject_filter,
-            **processed_filter,
-            **modality_filter
+    # Filter by task
+    #   "Uncoupled Baiting",
+    #   "Coupled Baiting",
+    #   "Uncoupled Without Baiting",
+    #   "Coupled Without Baiting",
+    # TODO, should update this section to filter for v1 or v2 or both acquisition systems
+    if len(task) > 0:
+        task_filter = {
+            "acquisition.stimulus_epochs.training_protocol_name": {"$in": task},
+            "acquisition.acquisition_type": "AindDynamicForaging",
         }
+    else:
+        task_filter = {
+            "acquisition.acquisition_type": "AindDynamicForaging",
+        }
+
+    # Filter by Stage
+    if len(stage) > 0:
+        stage_filter = {"acquisition.stimulus_epochs.curriculum_status": {"$in": stage}}
+    else:
+        stage_filter = {}
+
+    # extra_filter,
+    results = pd.DataFrame(
+        client.retrieve_docdb_records(
+            filter_query={
+                **subject_filter,
+                **processed_filter,
+                **modality_filter,
+                **task_filter,
+                **stage_filter,
+                **extra_filter,
+            },
+            projection=projection,
         )
-    return
+    )
+
+    # If nothing is found, return
+    if len(results) == 0:
+        print("No results found for {}".format(subjects))
+        return
+
+    # TODO, look for duplicate entries
+    # look for duplicate entries, taking the last by processing time
+    # results["session_name"] = [x.split("_processed")[0] for x in results["name"]]
+    # results = results.sort_values(by="name")
+    # results_no_duplicates = results.drop_duplicates(subset="session_name", keep="last").copy()
+
+    ## If there were duplicates, make a warning and print the duplicates
+    # if len(results) != len(results_no_duplicates):
+    #    duplicated = results[results.duplicated(subset="session_name", keep=False)]
+    #    warnings.warn("Duplicate session entries in docDB")
+    #    for index, row in duplicated.iterrows():
+    #        print("duplicated: {}".format(row["name"]))
+
+    # TODO make code ocean ID a column
+    ## Make code ocean ID a column
+    # results_no_duplicates["code_ocean_asset_id"] = [
+    #    link["Code Ocean"][0] if ("Code Ocean" in link) and (len(link["Code Ocean"]) > 0) else ""
+    #    for link in results_no_duplicates["external_links"]
+    # ]
+
+    # return results_no_duplicates.reset_index(drop=True)
+
+    return results
+
 
 def generate_data_asset_attach_params(data_asset_IDs, mount_point=None):
     """

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -54,6 +54,11 @@ def get_assets(metadata_version="v1", **kwargs):
     results = get_subject_assets(my_id)
     """
     if metadata_version == "v1":
+        warnings.warn(
+            "Using metadata v1 will be phased out, switch your workflows now to metadata v2",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_assets_v1(**kwargs)
     elif metadata_version == "v2":
         return get_assets_v2(**kwargs)
@@ -61,7 +66,7 @@ def get_assets(metadata_version="v1", **kwargs):
         raise ValueError(f"Unknown input argument {metadata_version}")
 
 
-def get_subject_assets(subject_id, **kwargs):
+def get_subject_assets(subject_id, metadata_version="v1", **kwargs):
     """
     Returns the docDB results for a subject. If duplicate entries exist, take the last
     based on processing time. Skips pavlovian task.
@@ -86,6 +91,12 @@ def get_subject_assets(subject_id, **kwargs):
     Example
     results = get_subject_assets(my_id)
     """
+    if metadata_version == "v1":
+        warnings.warn(
+            "Using metadata v1 will be phased out, switch your workflows now to metadata v2",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
     return get_assets(subjects=[subject_id], **kwargs)
 
 

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -226,51 +226,75 @@ def get_assets_v2(
     if len(modality) > 0:
         modality_filter = {"$and": []}
         for m in modality:
-            modality_filter["$and"].append({"data_description.modality.abbreviation": m})
+            modality_filter["$and"].append({"data_description.modalities.abbreviation": m})
     else:
         modality_filter = {}
 
-    # Filter by task
-    #   "Uncoupled Baiting",
-    #   "Coupled Baiting",
-    #   "Uncoupled Without Baiting",
-    #   "Coupled Without Baiting",
-    # TODO, should update this section to filter for v1 or v2 or both acquisition systems
-    # for v1, acquisition.acquisition_type will contain the task name
-    if len(task) > 0:
-        task_filter = {
-            "acquisition.stimulus_epochs.training_protocol_name": {"$in": task},
-            "acquisition.acquisition_type": "AindDynamicForaging",
-        }
-    else:
-        task_filter = {
-            "acquisition.acquisition_type": "AindDynamicForaging",
-        }
+    # Filter by task and stage
+    if "v1" in acquisition_version:
+        # Filter by Task
+        if len(task) == 0:
+            task = [
+                "Uncoupled Baiting",
+                "Coupled Baiting",
+                "Uncoupled Without Baiting",
+                "Coupled Without Baiting",
+            ]
+        task_filter = {"acquisition.acquisition_type": {"$in": task}}
 
-    # Filter by Stage
-    # TODO, if acquisition is v1, then need to check in:
-    # acquisition.stimulus_epochs.performance_metrics.output_parameters.task_parameters.stage_in_use
-    if len(stage) > 0:
-        stage_filter = {"acquisition.stimulus_epochs.curriculum_status": {"$in": stage}}
-    else:
-        stage_filter = {}
+        # Filter by Stage
+        if len(stage) > 0:
+            stage_filter = {
+                "acquisition.stimulus_epochs.performance_metrics.output_parameters.task_parameters.stage_in_use": {
+                    "$in": stage
+                }
+            }
+        else:
+            stage_filter = {}
 
-    # TODO, need to update this
-    ## What information to return
-    #if (len(input_projection) == 0) & len(subjects) == 0:
-    #    projection = {
-    #        "name": 1,
-    #        "_id": 1,
-    #        "session": 1,
-    #        "session_name": 1,
-    #        "external_links": 1,
-    #        "subject.subject_id": 1,
-    #        **input_projection,
-    #    }
-    #elif len(input_projection) > 0:
-    #    projection = input_projection
-    #else:
-    #    projection = None
+        # Combine Filters
+        v1_filter = {**task_filter, **stage_filter}
+    if "v2" in acquisition_version:
+        # Filter by Task
+        if len(task) > 0:
+            task_filter = {
+                "acquisition.stimulus_epochs.training_protocol_name": {"$in": task},
+                "acquisition.acquisition_type": "AindDynamicForaging",
+            }
+        else:
+            task_filter = {
+                "acquisition.acquisition_type": "AindDynamicForaging",
+            }
+
+        # Filter by Stage
+        if len(stage) > 0:
+            stage_filter = {"acquisition.stimulus_epochs.curriculum_status": {"$in": stage}}
+        else:
+            stage_filter = {}
+
+        # Combine filters
+        v2_filter = {**task_filter, **stage_filter}
+
+    # Determine which acquisition system to filter for
+    if ("v1" in acquisition_version) & ("v2" in acquisition_version):
+        task_filter = {"$or": [v1_filter, v2_filter]}
+    elif "v1" in acquisition_version:
+        task_filter = v1_filter
+    else:
+        task_filter = v2_filter
+
+    # What information to return
+    if (len(input_projection) == 0) & len(subjects) == 0:
+        projection = {
+            "name": 1,
+            "_id": 1,
+            "subject.subject_id": 1,
+            **input_projection,
+        }
+    elif len(input_projection) > 0:
+        projection = input_projection
+    else:
+        projection = None
 
     # extra_filter,
     results = pd.DataFrame(
@@ -280,7 +304,6 @@ def get_assets_v2(
                 **processed_filter,
                 **modality_filter,
                 **task_filter,
-                **stage_filter,
                 **extra_filter,
             },
             projection=projection,

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -11,6 +11,7 @@ Important utility functions for formatting the data
 
 import os
 import warnings
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -23,7 +24,7 @@ from codeocean.data_asset import DataAssetAttachParams
 from aind_dynamic_foraging_data_utils import nwb_utils
 
 
-def get_assets(metadata_version="v1", **kwargs):
+def get_assets(metadata_version: Literal["v1", "v2"] = "v1," **kwargs):
     """
     Top level function that queries either docdb v1 or v2
     metadata_version (str) either "v1" or "v2"
@@ -66,7 +67,7 @@ def get_assets(metadata_version="v1", **kwargs):
         raise ValueError(f"Unknown input argument {metadata_version}")
 
 
-def get_subject_assets(subject_id, metadata_version="v1", **kwargs):
+def get_subject_assets(subject_id, metadata_version: Literal["v1", "v2"] = "v1", **kwargs):
     """
     Returns the docDB results for a subject. If duplicate entries exist, take the last
     based on processing time. Skips pavlovian task.
@@ -97,7 +98,7 @@ def get_subject_assets(subject_id, metadata_version="v1", **kwargs):
             category=DeprecationWarning,
             stacklevel=2,
         )
-    return get_assets(subjects=[subject_id], **kwargs)
+    return get_assets(subjects=[subject_id], metadata_version=metadata_version, **kwargs)
 
 
 def get_assets_v1(  # NOQA: C901

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -24,7 +24,7 @@ from codeocean.data_asset import DataAssetAttachParams
 from aind_dynamic_foraging_data_utils import nwb_utils
 
 
-def get_assets(metadata_version: Literal["v1", "v2"] = "v1," ** kwargs):
+def get_assets(metadata_version: Literal["v1", "v2"] = "v1", **kwargs):
     """
     Top level function that queries either docdb v1 or v2
     metadata_version (str) either "v1" or "v2"

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -22,6 +22,16 @@ from codeocean.data_asset import DataAssetAttachParams
 
 from aind_dynamic_foraging_data_utils import nwb_utils
 
+def get_assets(metadata_version='v1',**kwargs):
+    '''
+    Top level function that queries either docdb v1 or v2
+    '''
+    if metadata_version == "v1":
+        return get_assets_v1(**kwargs)
+    elif metadata_version == "v2":
+        return get_assets_v2(**kwargs)
+    else:
+        raise ValueError(f"Unknown input argument {metadata_version}")
 
 def get_subject_assets(subject_id, **kwargs):
     """
@@ -51,7 +61,7 @@ def get_subject_assets(subject_id, **kwargs):
     return get_assets(subjects=[subject_id], **kwargs)
 
 
-def get_assets(  # NOQA: C901
+def get_assets_v1(  # NOQA: C901
     subjects=[],
     processed=True,
     task=[],
@@ -182,6 +192,50 @@ def get_assets(  # NOQA: C901
 
     return results_no_duplicates.reset_index(drop=True)
 
+def get_assets_v2(
+    subjects=[],
+    processed=True,
+    task=[],
+    modality=["behavior"],
+    stage=[],
+    acquisition_version=['v1','v2'],
+    extra_filter={},
+    input_projection={},
+):
+    # Create metadata client
+    client = MetadataDbClient(
+        host="api.allenneuraldynamics.org", version="v2" 
+    )
+
+    # Query based on subject id
+    if len(subjects) == 0:
+        print("Query will be slow without explicit subject ids")
+        subject_filter = {}
+    else:
+        subjects = [str(x) for x in subjects]
+        subject_filter = {"subject.subject_id": {"$in": subjects}}
+
+    # Do we want processed or raw assets
+    if processed:
+        processed_filter = {"data_description.data_level": "derived"}
+    else:
+        processed_filter = {"data_description.data_level": "raw"}
+
+    # modality_filter
+    # task_filter
+    #   need to figure out how to parse in v2
+
+                **stage_filter,
+                **extra_filter,
+            },
+            projection=projection,
+    results = pd.DataFrame(client.retrieve_docdb_records(
+        filter_query={
+            "acquisition.acquisition_type":"AindDynamicForaging",
+            **processed_filter
+        }
+        )
+    return
 
 def generate_data_asset_attach_params(data_asset_IDs, mount_point=None):
     """

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -26,6 +26,32 @@ from aind_dynamic_foraging_data_utils import nwb_utils
 def get_assets(metadata_version="v1", **kwargs):
     """
     Top level function that queries either docdb v1 or v2
+    metadata_version (str) either "v1" or "v2"
+
+    Returns the docDB results for a subject. If duplicate entries exist, take the last
+    based on processing time. Skips pavlovian task.
+    equivalent to get_assets(subjects=[subject_id])
+
+    subject_id (str or int) subject id to get assets for from docDB
+    processed (bool) if True, look for processed assets. If False, look for raw assets
+    task (list of strings), if empty, include all task variants: Uncoupled Baiting,
+        Coupled Baiting, Uncoupled Without Baiting, Coupled Without Baiting.
+        If not empty, only include the task variants provided.
+    modality (list of strings), required data modality. If empty list, does not filter
+        modalities should the data modality abbreviations, for example: behavior,
+        behavior-videos, fib, ecephys
+    stage (list of strings), if empty, include all training stages. Otherwise, only
+        return stages included in this list. Possible stage names include STAGE_1,
+        STAGE_1_WARMUP, STAGE_2, STAGE_3, STAGE_4, STAGE_FINAL, GRADUATED, None
+    extra_filter (dict), docdb query
+    input_projection, what fields to return. If empty, returns everything unless searching
+        for all subjects (subjects = [])
+
+    if metadata_version == "v2", can additionally accept kwarg:
+        acquisition_version = ["v1","v2"]
+
+    Example
+    results = get_subject_assets(my_id)
     """
     if metadata_version == "v1":
         return get_assets_v1(**kwargs)
@@ -54,11 +80,11 @@ def get_subject_assets(subject_id, **kwargs):
         return stages included in this list. Possible stage names include STAGE_1,
         STAGE_1_WARMUP, STAGE_2, STAGE_3, STAGE_4, STAGE_FINAL, GRADUATED, None
     extra_filter (dict), docdb query
+    input_projection, what fields to return. If empty, returns everything unless searching
+        for all subjects (subjects = [])
 
     Example
     results = get_subject_assets(my_id)
-    co_assets = attach_data(results['code_ocean_asset_id'].values)
-
     """
     return get_assets(subjects=[subject_id], **kwargs)
 
@@ -88,10 +114,11 @@ def get_assets_v1(  # NOQA: C901
         return stages included in this list. Possible stage names include STAGE_1,
         STAGE_1_WARMUP, STAGE_2, STAGE_3, STAGE_4, STAGE_FINAL, GRADUATED, None
     extra_filter (dict), docdb query
+    input_projection, what fields to return. If empty, returns everything unless searching
+        for all subjects (subjects = [])
 
     Example
-    results = get_assets(subjects=[my_id])
-    co_assets = attach_data(results['code_ocean_asset_id'].values)
+    results = get_assets_v1(subjects=[my_id])
     """
     # Create metadata client
     client = MetadataDbClient(
@@ -205,6 +232,30 @@ def get_assets_v2(  # NOQA C901
     extra_filter={},
     input_projection={},
 ):
+    """
+    Returns the docDB v2 results for a subject. If duplicate entries exist, take the last
+    based on processing time. Skips pavlovian task.
+
+    subjects (a list of strs or ints) subject ids to get assets for from docDB
+    processed (bool) if True, look for processed assets. If False, look for raw assets
+    task (list of strings), if empty, include all task variants: Uncoupled Baiting,
+        Coupled Baiting, Uncoupled Without Baiting, Coupled Without Baiting.
+        If not empty, only include the task variants provided.
+    modality (list of strings), required data modality. If empty list, does not filter
+        modalities should the data modality abbreviations, for example: behavior,
+        behavior-videos, fib, ecephys
+    stage (list of strings), if empty, include all training stages. Otherwise, only
+        return stages included in this list. Possible stage names include STAGE_1,
+        STAGE_1_WARMUP, STAGE_2, STAGE_3, STAGE_4, STAGE_FINAL, GRADUATED, None
+    acquisition_version (list of strings), which acquisition version to search for, can be
+        "v1" and or "v2"
+    extra_filter (dict), docdb query
+    input_projection, what fields to return. If empty, returns everything unless searching
+        for all subjects (subjects = [])
+
+    Example
+    results = get_assets_v2(subjects=[my_id])
+    """
     # Create metadata client
     client = MetadataDbClient(host="api.allenneuraldynamics.org", version="v2")
 

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -221,18 +221,34 @@ def get_assets_v2(
     else:
         processed_filter = {"data_description.data_level": "raw"}
 
-    # modality_filter
-    # task_filter
-    #   need to figure out how to parse in v2
+    # Filter by data modality
+    if len(modality) > 0:
+        modality_filter = {"$and": []}
+        for m in modality:
+            modality_filter["$and"].append({"data_description.modality.abbreviation": m})
+    else:
+        modality_filter = {}
+    
+    # Filter by task
+    # TODO, parse by acquisition version here ?
+    if len(task) == 0:
+        task = [
+            "Uncoupled Baiting",
+            "Coupled Baiting",
+            "Uncoupled Without Baiting",
+            "Coupled Without Baiting",
+            "AindDynamicForaging"
+        ]
+    task_filter = {"acquisition.acquisition_type": {"$in": task}}
 
-                **stage_filter,
-                **extra_filter,
-            },
-            projection=projection,
+    # stage_filter,
+    # extra_filter,
+    # projection=projection,
     results = pd.DataFrame(client.retrieve_docdb_records(
         filter_query={
-            "acquisition.acquisition_type":"AindDynamicForaging",
-            **processed_filter
+            **subject_filter,
+            **processed_filter,
+            **modality_filter
         }
         )
     return

--- a/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
+++ b/src/aind_dynamic_foraging_data_utils/code_ocean_utils.py
@@ -24,7 +24,7 @@ from codeocean.data_asset import DataAssetAttachParams
 from aind_dynamic_foraging_data_utils import nwb_utils
 
 
-def get_assets(metadata_version: Literal["v1", "v2"] = "v1," **kwargs):
+def get_assets(metadata_version: Literal["v1", "v2"] = "v1," ** kwargs):
     """
     Top level function that queries either docdb v1 or v2
     metadata_version (str) either "v1" or "v2"
@@ -47,12 +47,10 @@ def get_assets(metadata_version: Literal["v1", "v2"] = "v1," **kwargs):
     extra_filter (dict), docdb query
     input_projection, what fields to return. If empty, returns everything unless searching
         for all subjects (subjects = [])
+    metadata_version (Literal["v1","v2"]) Which version of the AIND metadata to query
+        if metadata_version == "v2", can additionally accept kwarg:
+            acquisition_version = ["v1","v2"]
 
-    if metadata_version == "v2", can additionally accept kwarg:
-        acquisition_version = ["v1","v2"]
-
-    Example
-    results = get_subject_assets(my_id)
     """
     if metadata_version == "v1":
         warnings.warn(
@@ -88,6 +86,9 @@ def get_subject_assets(subject_id, metadata_version: Literal["v1", "v2"] = "v1",
     extra_filter (dict), docdb query
     input_projection, what fields to return. If empty, returns everything unless searching
         for all subjects (subjects = [])
+    metadata_version (Literal["v1","v2"]) Which version of the AIND metadata to query
+        if metadata_version == "v2", can additionally accept kwarg:
+            acquisition_version = ["v1","v2"]
 
     Example
     results = get_subject_assets(my_id)


### PR DESCRIPTION
- resolves #159 
- Allows users to flexibly search for metadata v1 or v2
- Allows users to flexibly search for assets created by acquisition software v1 or v2
- Adds some deprecation warnings to old functions
- I'm leaving the default behavior to search the v1 metadata for now - but added warnings that people should update their workflows to use metadata v2